### PR TITLE
Fixed issue #15 - Attribute name clashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can use your own colors in two ways.
 <!-- REFERENCE THE ARRAY IN LAYOUT FILE -->
 <com.cengalabs.flatui.views.FlatButton
     ...
-    flatui:theme="@array/custom_theme" />
+    flatui:flatui_theme="@array/custom_theme" />
 
 ```
 
@@ -123,7 +123,7 @@ Place your font file in assets/fonts/ folder of your project and use fontFamily 
 
 These are only common attributes for most of the views. You can see the full list of available attributes in [attrs.xml][3]
 
-- theme          :  theme of the element (reference: @array/themeName)
+- flatui_theme          :  theme of the element (reference: @array/themeName)
 
 - textAppearance :  text color on the element. dark or light colors of the theme.(none, dark, light)
 - fontFamily     :  name of the font family (string)
@@ -146,7 +146,7 @@ xmlns:flatui="http://schemas.android.com/apk/res-auto"
 <!-- General Attributes -->
 <com.cengalabs.flatui.views.SomeFlatView
     ...
-    flatui:theme="@array/sand"
+    flatui:flatui_theme="@array/sand"
     flatui:textAppearance="dark"
     flatui:fontFamily="roboto"
     flatui:fontWeight="light"

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatButton.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatButton.java
@@ -52,7 +52,7 @@ public class FlatButton extends Button implements Attributes.AttributeChangeList
             TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.FlatButton);
 
             // getting common attributes
-            int customTheme = a.getResourceId(R.styleable.FlatButton_theme, Attributes.DEFAULT_THEME);
+            int customTheme = a.getResourceId(R.styleable.FlatButton_flatui_theme, Attributes.DEFAULT_THEME);
             attributes.setThemeSilent(customTheme, getResources());
 
             attributes.setFontFamily(a.getString(R.styleable.FlatButton_fontFamily));

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatCheckBox.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatCheckBox.java
@@ -52,7 +52,7 @@ public class FlatCheckBox extends CheckBox implements Attributes.AttributeChange
             TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.FlatCheckBox);
 
             // getting common attributes
-            int customTheme = a.getResourceId(R.styleable.FlatCheckBox_theme, Attributes.DEFAULT_THEME);
+            int customTheme = a.getResourceId(R.styleable.FlatCheckBox_flatui_theme, Attributes.DEFAULT_THEME);
             attributes.setThemeSilent(customTheme, getResources());
 
             attributes.setFontFamily(a.getString(R.styleable.FlatButton_fontFamily));

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatEditText.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatEditText.java
@@ -55,7 +55,7 @@ public class FlatEditText extends EditText implements Attributes.AttributeChange
             TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.FlatEditText);
 
             // getting common attributes
-            int customTheme = a.getResourceId(R.styleable.FlatEditText_theme, Attributes.DEFAULT_THEME);
+            int customTheme = a.getResourceId(R.styleable.FlatEditText_flatui_theme, Attributes.DEFAULT_THEME);
             attributes.setThemeSilent(customTheme, getResources());
 
             attributes.setFontFamily(a.getString(R.styleable.FlatEditText_fontFamily));

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatRadioButton.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatRadioButton.java
@@ -52,7 +52,7 @@ public class FlatRadioButton extends RadioButton implements Attributes.Attribute
             TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.FlatRadioButton);
 
             // getting common attributes
-            int customTheme = a.getResourceId(R.styleable.FlatRadioButton_theme, Attributes.DEFAULT_THEME);
+            int customTheme = a.getResourceId(R.styleable.FlatRadioButton_flatui_theme, Attributes.DEFAULT_THEME);
             attributes.setThemeSilent(customTheme, getResources());
 
             attributes.setFontFamily(a.getString(R.styleable.FlatRadioButton_fontFamily));

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatSeekBar.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatSeekBar.java
@@ -45,7 +45,7 @@ public class FlatSeekBar extends SeekBar implements Attributes.AttributeChangeLi
             TypedArray a = getContext().obtainStyledAttributes(attrs, com.cengalabs.flatui.R.styleable.FlatSeekBar);
 
             // getting common attributes
-            int customTheme = a.getResourceId(com.cengalabs.flatui.R.styleable.FlatSeekBar_theme, Attributes.DEFAULT_THEME);
+            int customTheme = a.getResourceId(com.cengalabs.flatui.R.styleable.FlatSeekBar_flatui_theme, Attributes.DEFAULT_THEME);
             attributes.setThemeSilent(customTheme, getResources());
 
             attributes.setSize(a.getDimensionPixelSize(com.cengalabs.flatui.R.styleable.FlatSeekBar_size, Attributes.DEFAULT_SIZE));

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatTextView.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatTextView.java
@@ -65,7 +65,7 @@ public class FlatTextView extends TextView implements Attributes.AttributeChange
             TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.FlatTextView);
 
             // getting common attributes
-            int customTheme = a.getResourceId(R.styleable.FlatTextView_theme, Attributes.DEFAULT_THEME);
+            int customTheme = a.getResourceId(R.styleable.FlatTextView_flatui_theme, Attributes.DEFAULT_THEME);
             attributes.setThemeSilent(customTheme, getResources());
 
             attributes.setFontFamily(a.getString(R.styleable.FlatTextView_fontFamily));

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatToggleButton.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatToggleButton.java
@@ -51,7 +51,7 @@ public class FlatToggleButton extends ToggleButton implements Attributes.Attribu
             TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.FlatToggleButton);
 
             // getting common attributes
-            int customTheme = a.getResourceId(R.styleable.FlatToggleButton_theme, Attributes.DEFAULT_THEME);
+            int customTheme = a.getResourceId(R.styleable.FlatToggleButton_flatui_theme, Attributes.DEFAULT_THEME);
             attributes.setThemeSilent(customTheme, getResources());
 
             attributes.setRadius(a.getDimensionPixelSize(R.styleable.FlatToggleButton_cornerRadius, Attributes.DEFAULT_RADIUS));

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <attr name="theme" format="reference" />
+    <attr name="flatui_theme" format="reference" />
 
     <attr name="fontFamily" format="string" />
     <attr name="fontWeight" format="string" />
@@ -20,7 +20,7 @@
 
     <!-- FlatButton -->
     <declare-styleable name="FlatButton">
-        <attr name="theme" />
+        <attr name="flatui_theme" />
         <attr name="fontFamily" />
         <attr name="fontWeight" />
         <attr name="fontExtension" />
@@ -33,7 +33,7 @@
 
     <!-- Flat Check Box -->
     <declare-styleable name="FlatCheckBox">
-        <attr name="theme" />
+        <attr name="flatui_theme" />
         <attr name="fontFamily" />
         <attr name="fontWeight" />
         <attr name="fontExtension" />
@@ -44,7 +44,7 @@
 
     <!-- Flat Edit Text -->
     <declare-styleable name="FlatEditText">
-        <attr name="theme" />
+        <attr name="flatui_theme" />
         <attr name="fontFamily" />
         <attr name="fontWeight" />
         <attr name="fontExtension" />
@@ -60,7 +60,7 @@
 
     <!-- Flat Radio Button -->
     <declare-styleable name="FlatRadioButton">
-        <attr name="theme" />
+        <attr name="flatui_theme" />
         <attr name="fontFamily" />
         <attr name="fontWeight" />
         <attr name="fontExtension" />
@@ -71,13 +71,13 @@
 
     <!-- Flat Seek Bar -->
     <declare-styleable name="FlatSeekBar">
-        <attr name="theme" />
+        <attr name="flatui_theme" />
         <attr name="size" />
     </declare-styleable>
 
     <!-- Flat Text View -->
     <declare-styleable name="FlatTextView">
-        <attr name="theme" />
+        <attr name="flatui_theme" />
         <attr name="fontFamily" />
         <attr name="fontWeight" />
         <attr name="fontExtension" />
@@ -100,7 +100,7 @@
 
     <!-- Flat Toggle Button -->
     <declare-styleable name="FlatToggleButton">
-        <attr name="theme" />
+        <attr name="flatui_theme" />
         <attr name="cornerRadius" />
         <attr name="space" format="dimension" />
     </declare-styleable>


### PR DESCRIPTION
As per issue #15 and #14, I've renamed all attributes to have a prefix `flatui_`.

I'm not sure about other complications this will bring later because I only use the theme via xml. Please do fix this if it exists in the programmatic way as well. _Or maybe, there is a better way to do this_.

Also, please read README.md for the changes that has to be made in existing app.

tl;dr you need to change the `flatui:theme` to `flatui:flatui_theme`
