### PR TITLE
Fix for issue #18 "Strange Issue on Consecutive Activity Opening". Chang...

### DIFF
--- a/library/src/main/java/com/cengalabs/flatui/Attributes.java
+++ b/library/src/main/java/com/cengalabs/flatui/Attributes.java
@@ -17,9 +17,13 @@ public class Attributes {
     public static final String DEFAULT_FONT_EXTENSION = "ttf";
     public static final int DEFAULT_TEXT_APPEARANCE = 0;
 
-    public static int DEFAULT_RADIUS = 4;
-    public static int DEFAULT_BORDER_WIDTH = 2;
-    public static int DEFAULT_SIZE = 10;
+    public static int DEFAULT_RADIUS_DP = 4;
+    public static int DEFAULT_BORDER_WIDTH_DP = 2;
+    public static int DEFAULT_SIZE_DP = 10;
+    
+    public static int DEFAULT_RADIUS_PX = 8;
+    public static int DEFAULT_BORDER_WIDTH_PX = 4;
+    public static int DEFAULT_SIZE_PX = 20;
 
     /**
      * Color related fields
@@ -38,9 +42,9 @@ public class Attributes {
     /**
      * Size related fields
      */
-    private int radius = DEFAULT_RADIUS;
-    private int size = DEFAULT_SIZE;
-    private int borderWidth = DEFAULT_BORDER_WIDTH;
+    private int radius = DEFAULT_RADIUS_PX;
+    private int size = DEFAULT_SIZE_PX;
+    private int borderWidth = DEFAULT_BORDER_WIDTH_PX;
 
     /**
      * Attribute change listener. Used to redraw the view when attributes are changed.

--- a/library/src/main/java/com/cengalabs/flatui/FlatUI.java
+++ b/library/src/main/java/com/cengalabs/flatui/FlatUI.java
@@ -37,9 +37,9 @@ public class FlatUI {
      */
     public static void initDefaultValues(Context context) {
 
-        Attributes.DEFAULT_BORDER_WIDTH = (int) dipToPx(context, Attributes.DEFAULT_BORDER_WIDTH);
-        Attributes.DEFAULT_RADIUS = (int) dipToPx(context, Attributes.DEFAULT_RADIUS);
-        Attributes.DEFAULT_SIZE = (int) dipToPx(context, Attributes.DEFAULT_SIZE);
+        Attributes.DEFAULT_BORDER_WIDTH_PX = (int) dipToPx(context, Attributes.DEFAULT_BORDER_WIDTH_DP);
+        Attributes.DEFAULT_RADIUS_PX = (int) dipToPx(context, Attributes.DEFAULT_RADIUS_DP);
+        Attributes.DEFAULT_SIZE_PX = (int) dipToPx(context, Attributes.DEFAULT_SIZE_DP);
     }
 
     /**

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatButton.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatButton.java
@@ -60,7 +60,7 @@ public class FlatButton extends Button implements Attributes.AttributeChangeList
             attributes.setFontExtension(a.getString(R.styleable.FlatButton_fontExtension));
 
             attributes.setTextAppearance(a.getInt(R.styleable.FlatButton_textAppearance, Attributes.DEFAULT_TEXT_APPEARANCE));
-            attributes.setRadius(a.getDimensionPixelSize(R.styleable.FlatButton_cornerRadius, Attributes.DEFAULT_RADIUS));
+            attributes.setRadius(a.getDimensionPixelSize(R.styleable.FlatButton_cornerRadius, Attributes.DEFAULT_RADIUS_PX));
 
             // getting view specific attributes
             bottom = a.getDimensionPixelSize(R.styleable.FlatButton_blockButtonEffectHeight, bottom);

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatCheckBox.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatCheckBox.java
@@ -59,8 +59,8 @@ public class FlatCheckBox extends CheckBox implements Attributes.AttributeChange
             attributes.setFontWeight(a.getString(R.styleable.FlatButton_fontWeight));
             attributes.setFontExtension(a.getString(R.styleable.FlatCheckBox_fontExtension));
 
-            attributes.setSize(a.getDimensionPixelSize(R.styleable.FlatCheckBox_size, Attributes.DEFAULT_SIZE));
-            attributes.setRadius(a.getDimensionPixelSize(R.styleable.FlatCheckBox_cornerRadius, Attributes.DEFAULT_RADIUS));
+            attributes.setSize(a.getDimensionPixelSize(R.styleable.FlatCheckBox_size, Attributes.DEFAULT_SIZE_PX));
+            attributes.setRadius(a.getDimensionPixelSize(R.styleable.FlatCheckBox_cornerRadius, Attributes.DEFAULT_RADIUS_PX));
             attributes.setBorderWidth(attributes.getSize() / 10);
 
             // getting view specific attributes

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatEditText.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatEditText.java
@@ -63,8 +63,8 @@ public class FlatEditText extends EditText implements Attributes.AttributeChange
             attributes.setFontExtension(a.getString(R.styleable.FlatEditText_fontExtension));
 
             attributes.setTextAppearance(a.getInt(R.styleable.FlatEditText_textAppearance, Attributes.DEFAULT_TEXT_APPEARANCE));
-            attributes.setRadius(a.getDimensionPixelSize(R.styleable.FlatEditText_cornerRadius, Attributes.DEFAULT_RADIUS));
-            attributes.setBorderWidth(a.getDimensionPixelSize(R.styleable.FlatEditText_borderWidth, Attributes.DEFAULT_BORDER_WIDTH));
+            attributes.setRadius(a.getDimensionPixelSize(R.styleable.FlatEditText_cornerRadius, Attributes.DEFAULT_RADIUS_PX));
+            attributes.setBorderWidth(a.getDimensionPixelSize(R.styleable.FlatEditText_borderWidth, Attributes.DEFAULT_BORDER_WIDTH_PX));
 
             // getting view specific attributes
             style = a.getInt(R.styleable.FlatEditText_fieldStyle, 0);

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatRadioButton.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatRadioButton.java
@@ -59,9 +59,9 @@ public class FlatRadioButton extends RadioButton implements Attributes.Attribute
             attributes.setFontWeight(a.getString(R.styleable.FlatRadioButton_fontWeight));
             attributes.setFontExtension(a.getString(R.styleable.FlatRadioButton_fontExtension));
 
-            attributes.setSize(a.getDimensionPixelSize(R.styleable.FlatRadioButton_size, Attributes.DEFAULT_SIZE));
+            attributes.setSize(a.getDimensionPixelSize(R.styleable.FlatRadioButton_size, Attributes.DEFAULT_SIZE_PX));
             attributes.setRadius(attributes.getSize() / 2);
-            attributes.setBorderWidth(a.getDimensionPixelSize(R.styleable.FlatRadioButton_borderWidth, Attributes.DEFAULT_BORDER_WIDTH));
+            attributes.setBorderWidth(a.getDimensionPixelSize(R.styleable.FlatRadioButton_borderWidth, Attributes.DEFAULT_BORDER_WIDTH_PX));
 
             // getting view specific attributes
             dotMargin = a.getDimensionPixelSize(R.styleable.FlatRadioButton_dotMargin, dotMargin);

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatSeekBar.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatSeekBar.java
@@ -48,7 +48,7 @@ public class FlatSeekBar extends SeekBar implements Attributes.AttributeChangeLi
             int customTheme = a.getResourceId(com.cengalabs.flatui.R.styleable.FlatSeekBar_theme, Attributes.DEFAULT_THEME);
             attributes.setThemeSilent(customTheme, getResources());
 
-            attributes.setSize(a.getDimensionPixelSize(com.cengalabs.flatui.R.styleable.FlatSeekBar_size, Attributes.DEFAULT_SIZE));
+            attributes.setSize(a.getDimensionPixelSize(com.cengalabs.flatui.R.styleable.FlatSeekBar_size, Attributes.DEFAULT_SIZE_PX));
 
             a.recycle();
         }

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatTextView.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatTextView.java
@@ -72,7 +72,7 @@ public class FlatTextView extends TextView implements Attributes.AttributeChange
             attributes.setFontWeight(a.getString(R.styleable.FlatTextView_fontWeight));
             attributes.setFontExtension(a.getString(R.styleable.FlatTextView_fontExtension));
 
-            attributes.setRadius(a.getDimensionPixelSize(R.styleable.FlatTextView_cornerRadius, Attributes.DEFAULT_RADIUS));
+            attributes.setRadius(a.getDimensionPixelSize(R.styleable.FlatTextView_cornerRadius, Attributes.DEFAULT_RADIUS_PX));
             attributes.setBorderWidth(a.getDimensionPixelSize(R.styleable.FlatTextView_borderWidth, 0));
 
             // getting view specific attributes

--- a/library/src/main/java/com/cengalabs/flatui/views/FlatToggleButton.java
+++ b/library/src/main/java/com/cengalabs/flatui/views/FlatToggleButton.java
@@ -54,7 +54,7 @@ public class FlatToggleButton extends ToggleButton implements Attributes.Attribu
             int customTheme = a.getResourceId(R.styleable.FlatToggleButton_theme, Attributes.DEFAULT_THEME);
             attributes.setThemeSilent(customTheme, getResources());
 
-            attributes.setRadius(a.getDimensionPixelSize(R.styleable.FlatToggleButton_cornerRadius, Attributes.DEFAULT_RADIUS));
+            attributes.setRadius(a.getDimensionPixelSize(R.styleable.FlatToggleButton_cornerRadius, Attributes.DEFAULT_RADIUS_PX));
 
             space = a.getDimensionPixelSize(R.styleable.FlatToggleButton_space, space);
             padding = space / 10;


### PR DESCRIPTION
...e naming of size variables and introducing new variables, so pixel size calculation is not done in relation to the same variable, what caused size to continuously increase when going back and opening application again.

Bug was caused by FlatUI.initDefaultValues(this), (usually used in onCreate, I suppose) where values are calculated in relation to themselves, like 
 Attributes.DEFAULT_SIZE = (int) dipToPx(context, Attributes.DEFAULT_SIZE);
Attributes.DEFAULT_SIZE is not always created from scratch when user leaves app and launches it again. That causes Attributes.DEFAULT_SIZE to increase every time app is launched - the bigger screen density the higher that growth.
I introduced Attributes.DEFAULT_SIZE_PX and Attributes.DEFAULT_SIZE_DP, so base value is always in dp and PX will be calculated in relation to it.
